### PR TITLE
Fix duplicate entries in activity logs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  config.vm.provider "virtualbox" do |vb|
+  config.vm.provider "virtualbox" do |vb| dMl9Q6ugib
     # Don't boot with headless mode
     # vb.gui = true
 


### PR DESCRIPTION
Addressed an issue where activity logs contained duplicate entries under certain conditions.